### PR TITLE
Mobile callback after OAuth login

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,19 +1,28 @@
 import Boom from '@hapi/boom';
 import config from 'config';
-const mobileCallbackUrl = config.get('osmOAuth.mobileCallbackUrl');
+const allowedRedirectURLs = config.get('osmOAuth.allowedRedirectURLs');
 
 const handler = function (request, h) {
   const { isAuthenticated, credentials } = request.auth;
-
+  const redirectTo = credentials.query.redirect;
   if (!isAuthenticated) {
     return Boom.unauthorized('Could not authenticate at OpenStreetMap.');
   }
 
-  // Redirect based on the route
-  if (request.url.pathname === '/login/mobile') {
-    return h.redirect(
-      `${mobileCallbackUrl}?#accessToken=${credentials.accessToken}`
-    );
+  // If `redirect` is passed
+  if (redirectTo) {
+    // Check if redirect URL is part of authorized list
+    for (let i = 0; i < allowedRedirectURLs.length; i++) {
+      const url = allowedRedirectURLs[i];
+      if (redirectTo.indexOf(url) === 0) {
+        return h.redirect(
+          `${redirectTo}?accessToken=${credentials.accessToken}`
+        );
+      }
+    }
+
+    // Return error if invalid redirect URL.
+    return Boom.badRequest('Invalid redirect URL.');
   } else {
     return {
       profile: credentials.profile,
@@ -25,14 +34,6 @@ const handler = function (request, h) {
 module.exports = [
   {
     path: '/login',
-    method: ['GET', 'POST'],
-    options: {
-      auth: 'openstreetmap',
-      handler
-    }
-  },
-  {
-    path: '/login/mobile',
     method: ['GET', 'POST'],
     options: {
       auth: 'openstreetmap',

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,4 +1,26 @@
 import Boom from '@hapi/boom';
+import config from 'config';
+const mobileCallbackUrl = config.get('osmOAuth.mobileCallbackUrl');
+
+const handler = function (request, h) {
+  const { isAuthenticated, credentials } = request.auth;
+
+  if (!isAuthenticated) {
+    return Boom.unauthorized('Could not authenticate at OpenStreetMap.');
+  }
+
+  // Redirect based on the route
+  if (request.url.pathname === '/login/mobile') {
+    return h.redirect(
+      `${mobileCallbackUrl}?#accessToken=${credentials.accessToken}`
+    );
+  } else {
+    return {
+      profile: credentials.profile,
+      accessToken: credentials.accessToken
+    };
+  }
+};
 
 module.exports = [
   {
@@ -6,18 +28,15 @@ module.exports = [
     method: ['GET', 'POST'],
     options: {
       auth: 'openstreetmap',
-      handler: function (request) {
-        const { isAuthenticated, credentials } = request.auth;
-
-        if (!isAuthenticated) {
-          return Boom.unauthorized('Could not authenticate at OpenStreetMap.');
-        }
-
-        return {
-          profile: credentials.profile,
-          accessToken: credentials.accessToken
-        };
-      }
+      handler
+    }
+  },
+  {
+    path: '/login/mobile',
+    method: ['GET', 'POST'],
+    options: {
+      auth: 'openstreetmap',
+      handler
     }
   }
 ];

--- a/config/default.json
+++ b/config/default.json
@@ -7,6 +7,7 @@
     "requestTokenUrl": "https://master.apis.dev.openstreetmap.org/oauth/request_token",
     "accessTokenUrl": "https://master.apis.dev.openstreetmap.org/oauth/access_token",
     "authorizeUrl": "https://master.apis.dev.openstreetmap.org/oauth/authorize",
-    "profileUrl": "https://master.apis.dev.openstreetmap.org/api/0.6/user/details"
+    "profileUrl": "https://master.apis.dev.openstreetmap.org/api/0.6/user/details",
+    "mobileCallbackUrl": "https://www.wikipedia.org"
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -8,6 +8,6 @@
     "accessTokenUrl": "https://master.apis.dev.openstreetmap.org/oauth/access_token",
     "authorizeUrl": "https://master.apis.dev.openstreetmap.org/oauth/authorize",
     "profileUrl": "https://master.apis.dev.openstreetmap.org/api/0.6/user/details",
-    "mobileCallbackUrl": "https://www.wikipedia.org"
+    "allowedRedirectURLs": ["http://localhost:3030"]
   }
 }


### PR DESCRIPTION
See: https://github.com/developmentseed/observe-api/issues/2.

Added route `/login/mobile` instead of trying to determine if the client is mobile. I believe it's a better approach to leave to the client to decide if it needs a deep link redirect. This avoids redirecting to a deep link if the user is accessing the dashboard via mobile browser.

The configuration option `mobileCallbackUrl` is used in the redirection. I've added a placeholder until we figure out the deep link.

cc @batpad @geohacker @sethvincent 

