### PR TITLE
Add GET /profile route

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -38,7 +38,8 @@ export default async function () {
       routes: [
         'app/routes/*.js',
         'app/routes/traces/*.js',
-        'app/routes/photos/*.js'
+        'app/routes/photos/*.js',
+        'app/routes/profile/*.js'
       ]
     }
   });

--- a/app/routes/profile/get.js
+++ b/app/routes/profile/get.js
@@ -1,0 +1,22 @@
+/**
+ * @apiGroup Users
+ *
+ * @api {get} /profile  2. GET /profile
+ * @apiDescription Get profile for the authenticated user.
+  *
+ * @apiUse AuthorizationHeader
+ *
+ * @apiUse Error4xx
+ */
+module.exports = [
+  {
+    path: '/profile',
+    method: ['GET'],
+    options: {
+      auth: 'jwt'
+    },
+    handler: async function (request) {
+      return request.auth.credentials;
+    }
+  }
+];

--- a/app/routes/users.js
+++ b/app/routes/users.js
@@ -3,8 +3,10 @@ import Joi from '@hapi/joi';
 import users from '../models/users';
 
 /**
- * @api {get} /users GET
  * @apiGroup Users
+ *
+ * @api {get} /users  1. GET /users
+ *
  * @apiDescription Provides a simple listing of users.
  *
  * @apiParam {number} [page=1] Paginate through results.

--- a/config/default.json
+++ b/config/default.json
@@ -10,7 +10,7 @@
     "accessTokenUrl": "https://master.apis.dev.openstreetmap.org/oauth/access_token",
     "authorizeUrl": "https://master.apis.dev.openstreetmap.org/oauth/authorize",
     "profileUrl": "https://master.apis.dev.openstreetmap.org/api/0.6/user/details",
-    "allowedRedirectURLs": ["http://localhost:3030"]
+    "allowedRedirectURLs": ["http://localhost:3030", "http://localhost:9000"]
   },
   "media": {
     "store": {

--- a/config/test.json
+++ b/config/test.json
@@ -1,5 +1,5 @@
 {
-  "port": 3001,
+  "port": 3002,
   "knex": {
     "client": "pg",
     "connection": {

--- a/test/test-users.js
+++ b/test/test-users.js
@@ -158,4 +158,29 @@ describe('Users endpoints', function () {
       }
     });
   });
+
+  describe('GET /profile', async function () {
+    it('returns 401 for non-authenticated user', async function () {
+      try {
+        const client = new Client(apiUrl);
+        await client.get('/profile');
+
+        // The test should never reach here, force execute catch block.
+        throw Error('An error was expected.');
+      } catch (error) {
+        // Check for the appropriate status response
+        expect(error.response.status).to.equal(401);
+      }
+    });
+
+    it('returns 200 and profile for authenticated user', async function () {
+      const user = await createMockUser();
+      const client = new Client(apiUrl);
+      await client.login(user.osmId);
+
+      // Default query, should be order by display name and match limit
+      const { data } = await client.get('/profile');
+      expect(data).to.deep.eq(user);
+    });
+  });
 });

--- a/test/test-users.js
+++ b/test/test-users.js
@@ -32,12 +32,6 @@ describe('Users endpoints', function () {
 
     // Get regular user for testing
     regularUser = users[users.length - 1];
-
-    // Parse date to string for easy comparison
-    users.map(r => {
-      r.osmCreatedAt = r.osmCreatedAt.toISOString();
-      return r;
-    });
   });
 
   describe('GET /users', function () {

--- a/test/utils/mock-factory.js
+++ b/test/utils/mock-factory.js
@@ -22,6 +22,10 @@ export async function createMockUser (data) {
     osmCreatedAt: new Date().toISOString()
   };
   const [user] = await users.create({ ...profile, ...data }).returning('*');
+
+  // Knex returns date objects, parse into string
+  user.osmCreatedAt = user.osmCreatedAt.toISOString();
+
   return user;
 }
 


### PR DESCRIPTION
A route that returns the authenticated user profile. This is necessary to complete the authentication cycle. After the redirection with access token, the frontend will access this route to test if token is valid and get authenticated user details.