### PR TITLE
[WIP] Populate development database task

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ Open a new terminal and migrate the database:
 
     npm run migrate-dev-db
 
+If your with to populate it with mock data, run:
+
+    npm run populate-dev-db
+
+Please consider that the last step will **wipe any previous data** from the development database.
+
 Start development server with changes monitoring:
 
     npm run dev
 
 Access the service at [localhost:3000](http://localhost:3000)
+
 
 When finished, go back to the first terminal session and kill the database container with Ctrl+C.
 

--- a/app/utils.js
+++ b/app/utils.js
@@ -10,3 +10,11 @@ export function appUrl () {
 export function mediaUrl () {
   return `${appUrl()}/media`;
 }
+
+/**
+ * Generate random integer number up to "max" value.
+ * @param {integer} max
+ */
+export function getRandomInt (max) {
+  return Math.floor(Math.random() * Math.floor(max));
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint": "node_modules/.bin/eslint app/ test/ --ext .js",
     "test": "NODE_ENV=test mocha -r esm test/test--index.js",
     "start-dev-db": "docker-compose -f docker-compose-dev.yml up",
+    "populate-dev-db": "NODE_ENV=development node -r esm -e 'require(\"./utils/populate-db.js\").populateDb()'",
     "start-test-db": "docker-compose -f docker-compose-test.yml up",
     "migrate-dev-db": "NODE_ENV=development node_modules/.bin/knex migrate:latest",
     "test-lint": "npm run lint && npm run test",

--- a/test/test--index.js
+++ b/test/test--index.js
@@ -1,9 +1,8 @@
 import config from 'config';
 import { expect } from 'chai';
 import startServer from '../app';
-import db from '../app/services/db';
 import logger from '../app/services/logger';
-import { clearMediaStore } from '../app/services/media-store';
+import resetDb from '../test/utils/reset-db';
 import Client from './utils/http-client';
 
 const port = config.get('port');
@@ -12,13 +11,7 @@ global.apiUrl = apiUrl;
 
 describe('Observe API', function () {
   before(async function () {
-    logger.info('Clearing database...');
-    await db.schema.dropTableIfExists('knex_migrations');
-    await db.schema.dropTableIfExists('users');
-    await db.schema.dropTableIfExists('traces');
-    await db.schema.dropTableIfExists('photos');
-    await db.migrate.latest();
-    await clearMediaStore();
+    await resetDb();
 
     logger.info('Starting server...');
     global.server = await startServer();

--- a/test/utils/mock-factory.js
+++ b/test/utils/mock-factory.js
@@ -2,14 +2,7 @@ import users from '../../app/models/users';
 import traces from '../../app/models/traces';
 import validTraceJson from '../fixtures/valid-trace.json';
 import { createPhoto } from '../../app/models/photos';
-
-/**
- * Generate random integer number up to "max" value.
- * @param {integer} max
- */
-function getRandomInt (max) {
-  return Math.floor(Math.random() * Math.floor(max));
-}
+import { getRandomInt } from '../../app/utils';
 
 /**
  * Factory to create mock users at the database.

--- a/test/utils/reset-db.js
+++ b/test/utils/reset-db.js
@@ -1,0 +1,13 @@
+import db from '../../app/services/db';
+import logger from '../../app/services/logger';
+import { clearMediaStore } from '../../app/services/media-store';
+
+export default async function resetDb () {
+  logger.info('Clearing database...');
+  await db.schema.dropTableIfExists('knex_migrations');
+  await db.schema.dropTableIfExists('users');
+  await db.schema.dropTableIfExists('traces');
+  await db.schema.dropTableIfExists('photos');
+  await db.migrate.latest();
+  await clearMediaStore();
+}

--- a/utils/populate-db.js
+++ b/utils/populate-db.js
@@ -1,0 +1,38 @@
+import resetDb from '../test/utils/reset-db';
+import { getRandomInt } from '../app/utils';
+import logger from '../app/services/logger';
+import {
+  createMockUser,
+  createMockTrace,
+  createMockPhoto
+} from '../test/utils/mock-factory';
+
+export async function populateDb () {
+  await resetDb();
+
+  logger.info(`Populating...`);
+
+  const numberOfUsers = 5;
+
+  // For each user
+  for (let u = 0; u < numberOfUsers; u++) {
+    const user = await createMockUser();
+
+    // Generate up to 25 traces
+    const numberOfTraces = getRandomInt(20) + 5;
+    for (let t = 0; t < numberOfTraces; t++) {
+      await createMockTrace(user.osmId);
+    }
+
+    // Generate up to 25 photos
+    const numberOfPhotos = getRandomInt(20) + 5;
+    for (let p = 0; p < numberOfPhotos; p++) {
+      await createMockPhoto(user.osmId);
+    }
+
+    logger.info(
+      `  Added user ${user.osmDisplayName} with ${numberOfTraces} traces and ${numberOfPhotos} photos.`
+    );
+  }
+  process.exit();
+}


### PR DESCRIPTION
Add `populate-dev-db`task, which will add mock users, traces and photos to the database. This will be useful until we have a staging env setup. To do:

- Randomize creation dates for traces and photos;
- Ability to set an admin user

