### PR TITLE
add observe://apilogin to default allowedRedirectURLs

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -10,7 +10,7 @@
     "accessTokenUrl": "https://master.apis.dev.openstreetmap.org/oauth/access_token",
     "authorizeUrl": "https://master.apis.dev.openstreetmap.org/oauth/authorize",
     "profileUrl": "https://master.apis.dev.openstreetmap.org/api/0.6/user/details",
-    "allowedRedirectURLs": ["http://localhost:3030", "http://localhost:9000"]
+    "allowedRedirectURLs": ["http://localhost:3030", "http://localhost:9000", "observe://apilogin"]
   },
   "media": {
     "store": {


### PR DESCRIPTION
This adds `observe://apilogin` to the default allowed redirect urls. This allows the browser to redirect the user back to the observe app using  the `observe://` protocol.

Tested this locally and it seems to be working well.