### PR TITLE
Allow empty descriptions

### DIFF
--- a/app/routes/photos/patch.js
+++ b/app/routes/photos/patch.js
@@ -37,7 +37,7 @@ export default [
           bearing: Joi.number()
             .max(360)
             .message('Invalid bearing.'),
-          description: Joi.string(),
+          description: Joi.string().empty(''),
           lon: Joi.number()
             .min(-180)
             .max(180),

--- a/app/routes/photos/post.js
+++ b/app/routes/photos/post.js
@@ -43,6 +43,7 @@ export default [
           bearing: Joi.number()
             .max(360)
             .required(),
+          description: Joi.string().empty(''),
           lon: Joi.number()
             .min(-180)
             .max(180)

--- a/app/routes/traces/patch.js
+++ b/app/routes/traces/patch.js
@@ -32,7 +32,7 @@ export default [
           id: Joi.string().length(idLength)
         }),
         payload: Joi.object({
-          description: Joi.string()
+          description: Joi.string().empty('')
         })
       },
       handler: async function (request) {

--- a/app/routes/traces/post.js
+++ b/app/routes/traces/post.js
@@ -29,7 +29,7 @@ export default [
           tracejson: Joi.object({
             type: Joi.valid('Feature'),
             properties: Joi.object({
-              description: Joi.string(),
+              description: Joi.string().empty(''),
               timestamps: Joi.array()
                 .min(2)
                 .items(Joi.number())


### PR DESCRIPTION
The API is returning a validation error for empty descriptions, which should be allowed.