### PR TITLE
Allowed redirection URLs configurable via env vars

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,6 +1,6 @@
 import Boom from '@hapi/boom';
 import config from 'config';
-const allowedRedirectURLs = config.get('osmOAuth.allowedRedirectURLs');
+const allowedRedirectURLs = config.get('osmOAuth.allowedRedirectURLs').split(',');
 
 const handler = function (request, h) {
   const { isAuthenticated, credentials } = request.auth;

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -8,7 +8,8 @@
     "requestTokenUrl": "OSM_OAUTH_TOKEN_URL",
     "accessTokenUrl": "OSM_OAUTH_ACCESS_TOKEN_URL",
     "authorizeUrl": "OSM_OAUTH_AUTHORIZE_URL",
-    "profileUrl": "OSM_OAUTH_PROFILE_URL"
+    "profileUrl": "OSM_OAUTH_PROFILE_URL",
+    "allowedRedirectURLs": "OSM_ALLOWED_REDIRECT_URLS"
   },
   "jwtSecret": "JWT_SECRET"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -13,7 +13,7 @@
     "accessTokenUrl": "https://master.apis.dev.openstreetmap.org/oauth/access_token",
     "authorizeUrl": "https://master.apis.dev.openstreetmap.org/oauth/authorize",
     "profileUrl": "https://master.apis.dev.openstreetmap.org/api/0.6/user/details",
-    "allowedRedirectURLs": ["http://localhost:3030", "http://localhost:9000", "observe://apilogin"]
+    "allowedRedirectURLs": "http://observe-dev.surge.sh,http://localhost:3030,http://localhost:9000,observe://apilogin"
   },
   "media": {
     "store": {


### PR DESCRIPTION
This makes more easy to add/remove allowed redirection URLs for the OAuth flow. This code was already deployed to the staging env.