### PR TITLE
Fix date query and trace patch

### DIFF
--- a/app/models/photos.js
+++ b/app/models/photos.js
@@ -152,7 +152,7 @@ function whereBuilder (builder, filterBy) {
   }
 
   if (endDate) {
-    builder.where('createdAt', '<=', endDate);
+    builder.where('createdAt', '<=', `${endDate}T23:59:59.999Z`);
   }
 
   if (osmElementType) {

--- a/app/models/traces.js
+++ b/app/models/traces.js
@@ -168,7 +168,7 @@ function whereBuilder (builder, filterBy) {
   }
 
   if (endDate) {
-    builder.where('recordedAt', '<=', endDate);
+    builder.where('recordedAt', '<=', `${endDate}T23:59:59.999Z`);
   }
 
   if (lengthMin) {

--- a/app/models/traces.js
+++ b/app/models/traces.js
@@ -110,7 +110,10 @@ export async function updateTrace (id, data) {
   // Update record
   await db('traces')
     .where('id', '=', id)
-    .update(data);
+    .update({
+      ...data,
+      updatedAt: new Date()
+    });
 
   return getTrace(id);
 }

--- a/test/test-traces.js
+++ b/test/test-traces.js
@@ -233,6 +233,7 @@ describe('Traces endpoints', async function () {
       // Load trace
       const updatedTrace = await getTrace(trace.id);
       expect(updatedTrace.description).to.deep.equal(newDescription);
+      expect(updatedTrace.updatedAt).not.equal(trace.updatedAt);
     });
 
     it('return 200 for non-owner admin', async function () {


### PR DESCRIPTION
Changes:

- Update trace's `updatedAt` on PATCH
- Use real end of the day when filtering by date

Affects #37, #42.