### PR TITLE
Allow absolute paths for media store

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -13,8 +13,13 @@ module.exports = {
   mediaStorePath: deferConfig(function () {
     // This calculate the absolute path to the media folder,
     // which will be used for file read/write operations
-    const appBasePath = path.join(__dirname, '..');
-    return path.join(appBasePath, this.media.store.path);
+    const mediaStorePath = this.media.store.path;
+    if (mediaStorePath.startsWith('/')) {
+      return path.normalize(mediaStorePath);
+    } else {
+      const appBasePath = path.join(__dirname, '..');
+      return path.join(appBasePath, this.media.store.path);
+    }
   }),
   mediaUrl: deferConfig(function () {
     return `${this.appUrl}/media`;


### PR DESCRIPTION
While updating the API at the staging environment I noticed we introduced a bug in #59. This [code block](https://github.com/developmentseed/observe-api/pull/59/files#diff-8002e202835020cde300ead3356515deR13-R18) transformed all media store path relative to the app root. 

This PR should fix this by checking if the passed path is absolute or relative, normalizing it accordingly.