### PR TITLE
Remove "import" statement from default config file

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,5 +1,5 @@
-import path from 'path';
-import { deferConfig } from 'config/defer';
+const path = require('path');
+const { deferConfig } = require('config/defer');
 
 /*
  * Default configuration values. This file makes use of deferConfig(), which


### PR DESCRIPTION
As `esm` module is not available when running migrations, I replaced the `import` statement.  This should fix #64. 