### PR TITLE
Feature/add metrics

### DIFF
--- a/app/models/observations.js
+++ b/app/models/observations.js
@@ -56,6 +56,7 @@ export async function fetchObservations (campaignId, surveyId, osmObjectId, user
         'observations.id',
         'observations.createdAt',
         'observations.uploadedAt',
+        'observations.campaignId',
         'userId',
         'surveyId',
         'osmObjectId',

--- a/app/services/badges/index.js
+++ b/app/services/badges/index.js
@@ -8,7 +8,7 @@ import metrics from './metrics';
  */
 export default async function () {
   const badgeDescriptions = await badges.listBadges();
-  const allObservations = await observations.fetchObservations();
+  const allObservations = await observations.getObservationsWithAnswers();
 
   // for each badge description
   // check the metric, and pass it to the appropriate

--- a/app/services/badges/metrics/index.js
+++ b/app/services/badges/metrics/index.js
@@ -1,7 +1,9 @@
 import numObservations from './numObservations';
+import numAnswersWithValue from './numAnswersWithValue';
 
 const metrics = {
-  numObservations
+  numObservations,
+  numAnswersWithValue
 };
 
 export default metrics;

--- a/app/services/badges/metrics/index.js
+++ b/app/services/badges/metrics/index.js
@@ -1,9 +1,11 @@
 import numObservations from './numObservations';
 import numAnswersWithValue from './numAnswersWithValue';
+import numObservationsInCampaign from './numObservationsInCampaign';
 
 const metrics = {
   numObservations,
-  numAnswersWithValue
+  numAnswersWithValue,
+  numObservationsInCampaign
 };
 
 export default metrics;

--- a/app/services/badges/metrics/numAnswersWithValue.js
+++ b/app/services/badges/metrics/numAnswersWithValue.js
@@ -1,23 +1,31 @@
-import { groupBy, prop, mapObjIndexed, map, filter, sort, forEachObjIndexed } from 'ramda';
+import { compose, groupBy, equals, path, prop, mapObjIndexed, map, filter, sort, forEachObjIndexed, any } from 'ramda';
 import { compareAsc } from 'date-fns';
 
 /**
- * Given all observations and a threshold, return the users that have had
- * _threshold_ observations and the time when they recorded that number of
- * observations
+ * Given all observations a threshold and a value, return the users that have had
+ * _threshold_ observations with that answer as a value
+ * and the time when they recorded that number of answers
  *
  * @param {Object} attributes
  * @param {Object} attributes.threshold - number of observations to achieve badge
  * @param {Observation[]} observations
  */
-export default function numObservations (attributes, observations) {
-  const { threshold } = attributes;
+export default function numAnswersWithValue (attributes, observations) {
+  const { threshold, answerValue } = attributes;
   if (!threshold || threshold < 1) {
     throw new Error('numObservations needs a positive integer threshold');
   }
 
+  // Filter observations for questions with the answerValue = value
+  const answerPredicate = compose(
+    any(equals(answerValue)),
+    map(path(['answer', 'value'])),
+    prop('answers')
+  );
+  const filteredObservations = filter(answerPredicate, observations);
+
   // Group observations by the user id
-  const userObservations = groupBy(prop('userId'), observations);
+  const userObservations = groupBy(prop('userId'), filteredObservations);
 
   // Filter only users that have more than _threshold_ observations
   const winners = filter((arr) => arr.length >= threshold, userObservations);

--- a/app/services/badges/metrics/numObservations.js
+++ b/app/services/badges/metrics/numObservations.js
@@ -7,7 +7,7 @@ import { compareAsc } from 'date-fns';
  * observations
  *
  * @param {Object} attributes
- * @param {Object} attributes.threshold - number of observations to achieve badge
+ * @param {integer} attributes.threshold - number of observations to achieve badge
  * @param {Observation[]} observations
  */
 export default function numObservations (attributes, observations) {

--- a/app/services/badges/metrics/numObservationsInCampaign.js
+++ b/app/services/badges/metrics/numObservationsInCampaign.js
@@ -1,29 +1,23 @@
-import { compose, groupBy, equals, path, prop, mapObjIndexed, map, filter, sort, forEachObjIndexed, any } from 'ramda';
+import { groupBy, prop, mapObjIndexed, map, filter, sort, forEachObjIndexed, propEq } from 'ramda';
 import { compareAsc } from 'date-fns';
 
 /**
- * Given all observations a threshold and a value, return the users that have had
- * _threshold_ observations with that answer as a value
- * and the time when they recorded that number of answers
+ * Given all observations a threshold and a campaignId, return the users that have had
+ * _threshold_ observations in that campaign
  *
  * @param {Object} attributes
  * @param {integer} attributes.threshold - number of observations to achieve badge
- * @param {string} attributes.answerValue - value of answers to filter by
+ * @param {integer} attributes.campaignId - campaignId to filter by
  * @param {Observation[]} observations
  */
-export default function numAnswersWithValue (attributes, observations) {
-  const { threshold, answerValue } = attributes;
+export default function numObservationsInCampaign (attributes, observations) {
+  const { threshold, campaignId } = attributes;
   if (!threshold || threshold < 1) {
     throw new Error('numObservations needs a positive integer threshold');
   }
 
-  // Filter observations for questions with the answerValue = value
-  const answerPredicate = compose(
-    any(equals(answerValue)),
-    map(path(['answer', 'value'])),
-    prop('answers')
-  );
-  const filteredObservations = filter(answerPredicate, observations);
+  // Filter observations in campaign
+  const filteredObservations = filter(propEq('campaignId', campaignId), observations);
 
   // Group observations by the user id
   const userObservations = groupBy(prop('userId'), filteredObservations);

--- a/scripts/calculate-badges.js
+++ b/scripts/calculate-badges.js
@@ -7,7 +7,9 @@ require = require('esm')(module); // eslint-disable-line
     await run();
     process.exit();
   } catch (error) {
-    process.stderr('Could not complete badge calculation.', error);
+    process.stderr.write('Could not complete badge calculation.\r\n');
+    process.stderr.write(error.message);
+    process.stderr.write('\r\n');
     process.exit(1);
   }
 }


### PR DESCRIPTION
Adds the following metrics for badge calculation:
* numObservationsInCampaign: Calculates the number of observations for a user contributed to a campaign with `campaignId` in the attributes, if it is above `threshold` then award the badge
* numAnswersWithValue: Calculates the number of answers for a user with the value `answerValue`, if it is above `threshold` then award the badge