### PR TITLE
Add campaigns seed

### DIFF
--- a/seeds/1-users.js
+++ b/seeds/1-users.js
@@ -1,15 +1,14 @@
 // Enable ECMAScript module loader
-require = require("esm")(module); // eslint-disable-line
+require = require('esm')(module); // eslint-disable-line
 
 const users = require('../app/models/users');
 const { createMockUser } = require('../test/utils/mock-factory');
 
-exports.seed = async function (knex) {
-
+exports.seed = async function(knex) {
   const usersCount = await users.count();
   if (usersCount > 0) {
     // eslint-disable-next-line
-    console.log('There are USERS in the database already, bypass seeding...'); 
+    console.log('There are USERS in the database already, bypass seeding...');
     return;
   }
 

--- a/seeds/1-users.js
+++ b/seeds/1-users.js
@@ -1,10 +1,19 @@
 // Enable ECMAScript module loader
 require = require("esm")(module); // eslint-disable-line
 
+const users = require('../app/models/users');
 const { createMockUser } = require('../test/utils/mock-factory');
 
 exports.seed = async function (knex) {
-  console.log('Seeding users...') // eslint-disable-line
+
+  const usersCount = await users.count();
+  if (usersCount > 0) {
+    // eslint-disable-next-line
+    console.log('There are USERS in the database already, bypass seeding...'); 
+    return;
+  }
+
+  console.log('Seeding users...'); // eslint-disable-line
 
   // Create 5 admins
   for (let i = 0; i < 5; i++) {

--- a/seeds/2-photos.js
+++ b/seeds/2-photos.js
@@ -1,9 +1,19 @@
 // Enable ECMAScript module loader
 require = require("esm")(module); // eslint-disable-line
 
+const photos = require('../app/models/photos');
 const { createMockPhoto, getRandomInt } = require('../test/utils/mock-factory');
 
 exports.seed = async function (knex) {
+
+  const photosCount = await photos.countPhotos();
+  if (photosCount > 0) {
+    // eslint-disable-next-line
+    console.log('There are PHOTOS in the database already, bypass seeding...'); 
+    return;
+  }
+
+
   console.log('Seeding photos...') // eslint-disable-line
 
   const users = await knex('users').select('id');

--- a/seeds/2-photos.js
+++ b/seeds/2-photos.js
@@ -1,27 +1,27 @@
 // Enable ECMAScript module loader
-require = require("esm")(module); // eslint-disable-line
+require = require('esm')(module); // eslint-disable-line
 
 const photos = require('../app/models/photos');
 const { createMockPhoto, getRandomInt } = require('../test/utils/mock-factory');
 
-exports.seed = async function (knex) {
-
+exports.seed = async function(knex) {
   const photosCount = await photos.countPhotos();
   if (photosCount > 0) {
     // eslint-disable-next-line
-    console.log('There are PHOTOS in the database already, bypass seeding...'); 
+    console.log('There are PHOTOS in the database already, bypass seeding...');
     return;
   }
 
-
-  console.log('Seeding photos...') // eslint-disable-line
+  console.log('Seeding photos...'); // eslint-disable-line
 
   const users = await knex('users').select('id');
 
   const totalUsers = users.length;
 
   if (users.length === 0) {
-    throw Error('No users found. Please login to create a user to associate mock data.');
+    throw Error(
+      'No users found. Please login to create a user to associate mock data.'
+    );
   }
 
   for (let i = 0; i < 50; i++) {

--- a/seeds/3-traces.js
+++ b/seeds/3-traces.js
@@ -1,9 +1,17 @@
 // Enable ECMAScript module loader
 require = require("esm")(module); // eslint-disable-line
 
+const traces = require('../app/models/traces');
 const { createMockTrace, getRandomInt } = require('../test/utils/mock-factory');
 
 exports.seed = async function (knex) {
+  const tracesCount = await traces.getTracesCount();
+  if (tracesCount > 0) {
+    // eslint-disable-next-line
+    console.log('There are TRACES in the database already, bypass seeding...'); 
+    return;
+  }
+
   console.log('Seeding traces...') // eslint-disable-line
 
   const users = await knex('users').select('id');

--- a/seeds/4-campaigns.js
+++ b/seeds/4-campaigns.js
@@ -1,0 +1,69 @@
+// Enable ECMAScript module loader
+require = require('esm')(module); // eslint-disable-line
+
+const db = require('../app/services/db');
+const { stringify } = require('wellknown');
+
+exports.seed = async function(knex) {
+  const {count} = await db('campaigns').count().first();
+  if (count > 0) {
+    // eslint-disable-next-line
+    console.log(
+      'There are CAMPAIGNS in the database already, bypass seeding...'
+    );
+    return;
+  }
+
+  console.log('Seeding campaigns...'); // eslint-disable-line
+
+  const adminId = (await db('users')
+    .select('id')
+    .where({ isAdmin: true })
+    .limit(1))[0].id;
+
+  await db('campaigns').insert({
+    name: 'Washington DC',
+    slug: 'washignton-dc',
+    aoi: stringify({
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-77.16796875, 38.77871080859691],
+            [-76.871337890625, 38.77871080859691],
+            [-76.871337890625, 39.00744617666487],
+            [-77.16796875, 39.00744617666487],
+            [-77.16796875, 38.77871080859691]
+          ]
+        ]
+      }
+    }),
+    surveys: [1],
+    ownerId: adminId
+  });
+
+  await db('campaigns').insert({
+    name: 'Boston',
+    slug: 'boston',
+    aoi: stringify({
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-71.13029479980469, 42.3016903282445],
+            [-70.98129272460938, 42.3016903282445],
+            [-70.98129272460938, 42.40064333382955],
+            [-71.13029479980469, 42.40064333382955],
+            [-71.13029479980469, 42.3016903282445]
+          ]
+        ]
+      }
+    }),
+    surveys: [1],
+    ownerId: adminId
+  });
+};

--- a/seeds/4-questions.js
+++ b/seeds/4-questions.js
@@ -1,0 +1,37 @@
+// Enable ECMAScript module loader
+require = require('esm')(module); // eslint-disable-line
+
+const db = require('../app/services/db');
+
+exports.seed = async function(knex) {
+  const { count } = await db('questions')
+    .count()
+    .first();
+  if (count > 0) {
+    // eslint-disable-next-line
+    console.log(
+      'There are QUESTIONS in the database already, bypass seeding...'
+    );
+    return;
+  }
+
+  console.log('Seeding questions...'); // eslint-disable-line
+
+  await db.raw('ALTER SEQUENCE questions_id_seq RESTART WITH 1');
+
+  await db('questions').insert({
+    version: 1,
+    label: 'Does this venue offer the option to purchase a plastic-free meal?',
+    type: 'boolean',
+    options: {
+      no: 'No',
+      yes: 'Yes'
+    }
+  });
+
+  await db('questions').insert({
+    version: 1,
+    label: 'Please describe packaging provided:',
+    type: 'text'
+  });
+};

--- a/seeds/5-surveys.js
+++ b/seeds/5-surveys.js
@@ -3,27 +3,6 @@ require = require('esm')(module); // eslint-disable-line
 
 const db = require('../app/services/db');
 
-const { getRandomInt } = require('../test/utils/mock-factory');
-const { createObservation } = require('../app/models/observations');
-const { add, formatISO } = require('date-fns');
-
-function generateAnswerValue(q) {
-  switch (q.type) {
-    case 'boolean':
-      return Math.random() > 0.3;
-    default:
-      return [
-        'Nostrud consequat veniam et eu minim ex minim labore magna cupidatat Lorem Lorem proident ad.',
-        'Amet mollit velit labore dolor sint id minim tempor nisi ullamco aute',
-        'Id esse tempor sunt sit ut. Id dolore aliquip non ea excepteur. Id sint incididunt',
-        'Lorem tempor ex enim occaecat ullamco ad Lorem commodo.',
-        'Officia velit quis labore ipsum sunt id reprehenderit duis fugiat consectetur.',
-        'Cillum velit adipisicing ex do enim ullamco ea eiusmod ad veniam reprehenderit.',
-        'Aute magna officia duis reprehenderit reprehenderit officia minim sint adipisicing deserunt officia anim.'
-      ][getRandomInt(6)];
-  }
-}
-
 exports.seed = async function(knex) {
   const { count } = await db('surveys')
     .count()
@@ -36,49 +15,17 @@ exports.seed = async function(knex) {
 
   console.log('Seeding surveys...'); // eslint-disable-line
 
-  const surveys = await knex('surveys').select('*');
+  const adminId = (await db('users')
+    .select('id')
+    .where({ isAdmin: true })
+    .limit(1))[0].id;
 
-  let dateAdded = new Date();
+  await db.raw('ALTER SEQUENCE surveys_id_seq RESTART WITH 1');
 
-  // For each survey
-  for (let s = 0; s < surveys.length; s++) {
-    const survey = surveys[s];
-    const questions = await knex('questions').whereIn('id', survey.questions);
-
-    const places = await knex('osm_objects')
-      .select('id', 'attributes as properties')
-      .offset(500)
-      .limit(1 + getRandomInt(200));
-    for (let p = 0; p < places.length; p++) {
-      const place = places[p];
-
-      const users = await knex('users')
-        .select('*')
-        .limit(1 + getRandomInt(10));
-
-      for (let u = 0; u < users.length; u++) {
-        dateAdded = add(dateAdded, { days: 1 });
-
-        const user = users[u];
-
-        const observation = {
-          surveyId: survey.id,
-          osmObject: place,
-          userId: user.id,
-          createdAt: formatISO(dateAdded),
-          answers: questions.map(q => {
-            return {
-              questionId: q.id,
-              questionVersion: q.version,
-              answer: {
-                value: generateAnswerValue(q)
-              }
-            };
-          })
-        };
-
-        await createObservation(observation);
-      }
-    }
-  }
+  await db('surveys').insert({
+    name: 'Survey packaging provided by businesses:',
+    questions: [1, 2],
+    optionalQuestions: [2],
+    ownerId: adminId
+  });
 };

--- a/seeds/5-surveys.js
+++ b/seeds/5-surveys.js
@@ -1,11 +1,13 @@
 // Enable ECMAScript module loader
-require = require("esm")(module); // eslint-disable-line
+require = require('esm')(module); // eslint-disable-line
+
+const db = require('../app/services/db');
 
 const { getRandomInt } = require('../test/utils/mock-factory');
 const { createObservation } = require('../app/models/observations');
-const { add, formatISO } = require('date-fns')
+const { add, formatISO } = require('date-fns');
 
-function generateAnswerValue (q) {
+function generateAnswerValue(q) {
   switch (q.type) {
     case 'boolean':
       return Math.random() > 0.3;
@@ -22,8 +24,17 @@ function generateAnswerValue (q) {
   }
 }
 
-exports.seed = async function (knex) {
-  console.log("Seeding surveys..."); // eslint-disable-line
+exports.seed = async function(knex) {
+  const { count } = await db('surveys')
+    .count()
+    .first();
+  if (count > 0) {
+    // eslint-disable-next-line
+    console.log('There are SURVEYS in the database already, bypass seeding...');
+    return;
+  }
+
+  console.log('Seeding surveys...'); // eslint-disable-line
 
   const surveys = await knex('surveys').select('*');
 
@@ -46,7 +57,7 @@ exports.seed = async function (knex) {
         .limit(1 + getRandomInt(10));
 
       for (let u = 0; u < users.length; u++) {
-        dateAdded = add(dateAdded, { days: 1 })
+        dateAdded = add(dateAdded, { days: 1 });
 
         const user = users[u];
 

--- a/seeds/6-campaigns.js
+++ b/seeds/6-campaigns.js
@@ -5,7 +5,9 @@ const db = require('../app/services/db');
 const { stringify } = require('wellknown');
 
 exports.seed = async function(knex) {
-  const {count} = await db('campaigns').count().first();
+  const { count } = await db('campaigns')
+    .count()
+    .first();
   if (count > 0) {
     // eslint-disable-next-line
     console.log(
@@ -15,6 +17,8 @@ exports.seed = async function(knex) {
   }
 
   console.log('Seeding campaigns...'); // eslint-disable-line
+
+  await db.raw('ALTER SEQUENCE campaigns_id_seq RESTART WITH 1');
 
   const adminId = (await db('users')
     .select('id')

--- a/seeds/6-campaigns.js
+++ b/seeds/6-campaigns.js
@@ -27,7 +27,7 @@ exports.seed = async function(knex) {
 
   await db('campaigns').insert({
     name: 'Washington DC',
-    slug: 'washignton-dc',
+    slug: 'washington-dc',
     aoi: stringify({
       type: 'Feature',
       properties: {},

--- a/seeds/7-observations.js
+++ b/seeds/7-observations.js
@@ -1,0 +1,85 @@
+// Enable ECMAScript module loader
+require = require('esm')(module); // eslint-disable-line
+
+const db = require('../app/services/db');
+
+const { getRandomInt } = require('../test/utils/mock-factory');
+const { createObservation } = require('../app/models/observations');
+const { add, formatISO } = require('date-fns');
+
+function generateAnswerValue(q) {
+  switch (q.type) {
+    case 'boolean':
+      return Math.random() > 0.3;
+    default:
+      return [
+        'Nostrud consequat veniam et eu minim ex minim labore magna cupidatat Lorem Lorem proident ad.',
+        'Amet mollit velit labore dolor sint id minim tempor nisi ullamco aute',
+        'Id esse tempor sunt sit ut. Id dolore aliquip non ea excepteur. Id sint incididunt',
+        'Lorem tempor ex enim occaecat ullamco ad Lorem commodo.',
+        'Officia velit quis labore ipsum sunt id reprehenderit duis fugiat consectetur.',
+        'Cillum velit adipisicing ex do enim ullamco ea eiusmod ad veniam reprehenderit.',
+        'Aute magna officia duis reprehenderit reprehenderit officia minim sint adipisicing deserunt officia anim.'
+      ][getRandomInt(6)];
+  }
+}
+
+exports.seed = async function(knex) {
+  const { count } = await db('observations')
+    .count()
+    .first();
+  if (count > 0) {
+    // eslint-disable-next-line
+    console.log('There are OBSERVATIONS in the database already, bypass seeding...');
+    return;
+  }
+
+  console.log('Seeding observations...'); // eslint-disable-line
+
+  const surveys = await knex('surveys').select('*');
+
+  let dateAdded = new Date();
+
+  // For each survey
+  for (let s = 0; s < surveys.length; s++) {
+    const survey = surveys[s];
+    const questions = await knex('questions').whereIn('id', survey.questions);
+
+    const places = await knex('osm_objects')
+      .select('id', 'attributes as properties')
+      .offset(500)
+      .limit(1 + getRandomInt(200));
+    for (let p = 0; p < places.length; p++) {
+      const place = places[p];
+
+      const users = await knex('users')
+        .select('*')
+        .limit(1 + getRandomInt(10));
+
+      for (let u = 0; u < users.length; u++) {
+        dateAdded = add(dateAdded, { days: 1 });
+
+        const user = users[u];
+
+        const observation = {
+          surveyId: survey.id,
+          osmObject: place,
+          userId: user.id,
+          campaignId: 1,
+          createdAt: formatISO(dateAdded),
+          answers: questions.map(q => {
+            return {
+              questionId: q.id,
+              questionVersion: q.version,
+              answer: {
+                value: generateAnswerValue(q)
+              }
+            };
+          })
+        };
+
+        await createObservation(observation);
+      }
+    }
+  }
+};


### PR DESCRIPTION
In order to dev/test campaigns (see https://github.com/developmentseed/plasticwatch/pull/125) in the frontend the API has to be seeded with campaign data. This will add Boston and Washington DC. List of changes:

- Check if DB is already populated, bypass if that is the case
- Add default questions and surveys from PlasticWatch campaigns
- Add Washington DC and Boston
- Reset id counters to ensure ids generated by seeding are always the same
- Add observations to Washington DC

I think this will be sufficient for our current needs, but I think we can improve by adding places to the database from overpass as a seed step.

To review I would suggest cleaning campaign-related data in the DB with:

```
delete from questions;
delete from answers;
delete from surveys;
delete from observations;
delete from campaigns;
```

And then running `yarn seed-dev`.
