### PR TITLE
Add only new osm objects 

### DIFF
--- a/app/models/osm-objects.js
+++ b/app/models/osm-objects.js
@@ -104,14 +104,11 @@ export async function getOsmObject (id) {
 }
 
 async function osmObjectExists (id) {
-  const obj = await db('osm_objects')
+  const [{ count }] = await db('osm_objects')
+    .count()
     .where('id', id);
 
-  if (obj) {
-    return true;
-  } else {
-    return false;
-  }
+  return parseInt(count) > 0;
 }
 
 export async function insertFeatureCollection (geojson) {

--- a/app/routes/osm-objects/post.js
+++ b/app/routes/osm-objects/post.js
@@ -33,9 +33,11 @@ export default [
       },
       handler: async function (request) {
         try {
+          logger.info('Parsing OSM objects...');
           // FIXME: should validate geojson feature collection here or above
-          const response = await insertFeatureCollection(request.payload);
-          return response;
+          const objectsCount = await insertFeatureCollection(request.payload);
+          logger.info(`Parsing completed, ${objectsCount} OSM object(s) added.`);
+          return objectsCount;
         } catch (error) {
           logger.error(error);
           return Boom.badImplementation('Unexpected error.');


### PR DESCRIPTION
@LanesGood @vgeorge this adds a change to the POST end point to only insert new osm objects to the database. This will make refreshing data a lot easier.